### PR TITLE
知乎专栏 去除教育&带货广告卡片，链接卡片自动转普通超链接

### DIFF
--- a/entrypoints/zhihu.content.ts
+++ b/entrypoints/zhihu.content.ts
@@ -5,14 +5,34 @@ export default defineContentScript({
   main() {
     // 获取文档的高度
     const docHeight = Math.max(
-      document.body.scrollHeight, document.documentElement.scrollHeight,
-      document.body.offsetHeight, document.documentElement.offsetHeight,
-      document.body.clientHeight, document.documentElement.clientHeight
+        document.body.scrollHeight, document.documentElement.scrollHeight,
+        document.body.offsetHeight, document.documentElement.offsetHeight,
+        document.body.clientHeight, document.documentElement.clientHeight
     );
 
     // 滚动到文档的最底部
     window.scrollTo(0, docHeight);
     window.scrollTo(0, 0);
+
+    document.querySelectorAll(".RichText-MCNLinkCardContainer").forEach((ad) => {
+      ad.parentNode?.removeChild(ad);
+    });
+
+    document.querySelectorAll(".RichText-EduCardContainer").forEach((ad) => {
+      ad.parentNode?.removeChild(ad);
+    });
+
+    document.querySelectorAll(".RichText-LinkCardContainer").forEach((link) => {
+      let a = link.querySelector("a");
+      let targetUrl = a?.getAttribute("href");
+      let targetText = a?.querySelector("span")?.querySelector("span")?.innerText;
+      if (targetUrl && targetText) {
+        let a = document.createElement("a");
+        a.href = targetUrl;
+        a.innerText = targetText;
+        link.parentNode?.replaceChild(a, link);
+      }
+    });
 
     let title = document.querySelector(".Post-Title")?.outerHTML;
     let titleText = document.title;
@@ -20,6 +40,6 @@ export default defineContentScript({
 
     var turndownService = new TurndownService()
     var markdown = turndownService.turndown(`${title}\n${content}`);
-    return { 'title': titleText, 'content': markdown };
+    return {'title': titleText, 'content': markdown};
   },
 });


### PR DESCRIPTION
自动移除 `.RichText-MCNLinkCardContainer`，`.RichText-EduCardContainer`。

把 `..RichText-LinkCardContainer` 自动提取为 `<a>`，只保留href和title（作为innterText）。